### PR TITLE
support pnpm v11 image builds

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -15,6 +15,11 @@ on:
         description: "the pnpm script name to build the project"
         required: false
         type: string
+      pnpm_version:
+        description: "the pnpm version to install"
+        required: false
+        type: string
+        default: "11"
       runner:
         description: "the runner to use, e.g. ubuntu-latest or 4c-16g"
         required: false
@@ -42,7 +47,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: ${{ inputs.pnpm_version }}
           run_install: false
       - name: Setup Node env
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Add a pnpm_version input to the reusable pnpm image build workflow.
- Default shared pnpm image builds to major version 11.
- Keep consumers able to override the pnpm version when needed.

## Validation
- yq e '.' .github/workflows/*.yml .github/dependabot.yml >/dev/null\n- git diff --check