### PR TITLE
avoid duplicate pnpm version sources

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -19,7 +19,7 @@ on:
         description: "the pnpm version to install"
         required: false
         type: string
-        default: "11"
+        default: ""
       runner:
         description: "the runner to use, e.g. ubuntu-latest or 4c-16g"
         required: false
@@ -44,7 +44,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm from packageManager
+        if: ${{ inputs.pnpm_version == '' }}
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup pnpm from workflow input
+        if: ${{ inputs.pnpm_version != '' }}
         uses: pnpm/action-setup@v4
         with:
           version: ${{ inputs.pnpm_version }}


### PR DESCRIPTION
## Summary

- Make packageManager the default pnpm version source in the reusable pnpm image build workflow.
- Only pass pnpm/action-setup version when callers explicitly provide pnpm_version.
- Keep pnpm_version available for consumers that do not define packageManager and want a major-only version such as 11.

## Root Cause

The previous workflow defaulted pnpm_version to 11, so repositories with packageManager: pnpm@11.3.0 caused pnpm/action-setup to see two pnpm versions and fail with "Multiple versions of pnpm specified".

## Validation

- yq e '.' .github/workflows/*.yml .github/dependabot.yml >/dev/null
- git diff --check
