### PR TITLE
upgrade frontend workflow actions to v6

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -43,20 +43,20 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm from packageManager
         if: ${{ inputs.pnpm_version == '' }}
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
       - name: Setup pnpm from workflow input
         if: ${{ inputs.pnpm_version != '' }}
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ inputs.pnpm_version }}
           run_install: false
       - name: Setup Node env
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -28,12 +28,12 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: ${{ inputs.lfs }}
       - run: corepack enable yarn
       - name: Setup Node env
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "yarn"

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -20,7 +20,7 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up CD tools
         uses: coscene-io/setup-cd-tools@v2.0.1
         env:


### PR DESCRIPTION
## Summary

- Upgrade frontend-related reusable workflow action majors.
- Update actions/checkout to v6 in image-push, image-push-pnpm, and image-push-yarn.
- Update actions/setup-node to v6 in image-push-pnpm and image-push-yarn.
- Update pnpm/action-setup to v6 in image-push-pnpm.

## Scope

Only frontend-related templates were changed:

- .github/workflows/image-push.yml
- .github/workflows/image-push-pnpm.yml
- .github/workflows/image-push-yarn.yml

## Validation

- yq e '.' .github/workflows/image-push-pnpm.yml .github/workflows/image-push-yarn.yml .github/workflows/image-push.yml >/dev/null
- git diff --check
