### PR TITLE
fix pnpm image tag build arg

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -90,18 +90,22 @@ jobs:
         id: build-and-push
         run: |
           PROFILE_ARG=$([ -n "${{ inputs.profile }}" ] && echo "-p ${{ inputs.profile }}" || echo "")
-          skaffold build --build-concurrency=0 $PROFILE_ARG -t latest
+          TAG=latest
           if [[ ${{ github.event_name }} == 'release' || ${{ github.event_name }} == 'prerelease' ]]; then
-            result=$(skaffold build --build-concurrency=0 $PROFILE_ARG -q | jq '.builds[0].tag')
+            result=$(skaffold build --build-concurrency=0 $PROFILE_ARG --dry-run -q | jq -r '.builds[0].tag')
             echo $result
             withoutRegistry=${result#*:}
             echo $withoutRegistry
             withoutDigest=${withoutRegistry%@*}
             echo $withoutDigest
-            echo "TAG=${withoutDigest}" >> $GITHUB_OUTPUT
-          else
-            echo "TAG=latest" >> $GITHUB_OUTPUT
+            TAG=${withoutDigest}
+            echo "IMAGE_TAG=${TAG}"
           fi
+          IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -t latest
+          if [[ $TAG != 'latest' ]]; then
+            IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -q
+          fi
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
   cp-image-to-volcengine:
     needs:


### PR DESCRIPTION
## Summary
- compute the release image tag before the pnpm skaffold build
- pass that tag through `IMAGE_TAG` for the `latest` build so runtime docker-config.js is not stuck on `latest` during release builds
- rebuild the release tag with the same `IMAGE_TAG` value so copied release images stay consistent

## Root Cause
The pnpm template built `latest` before computing the release tag. Dockerfiles that write `docker-config.js` from `ARG IMAGE_TAG` therefore received `latest`, while the date/version tag was computed later and never fed back into the build arg.

## Validation
- Node static snippet check for required workflow commands
- Bash simulation for release and push branches with fake `skaffold`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/image-push-pnpm.yml')"`
- `git diff --check`