### PR TITLE
fix volcengine image copy runner

### DIFF
--- a/.github/workflows/cp-image-to-volcengine.yml
+++ b/.github/workflows/cp-image-to-volcengine.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   cp-image-use-gh:
-    runs-on: ["aliyun", "X64"]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Summary
- run the Volcengine image copy workflow on `ubuntu-latest` instead of the currently unavailable `aliyun/X64` self-hosted runner

## Root Cause
The pnpm image build now passes the computed release tag through `IMAGE_TAG`, but the release workflows still remain queued because `cp-image-to-volcengine` waits for a self-hosted runner labeled `aliyun` and `X64`. Since the parent `image-push` reusable workflow does not complete until that copy job finishes, the downstream rollout job never starts.

## Validation
- Node static check verifying the workflow uses `ubuntu-latest` and no longer requires the `aliyun/X64` runner
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cp-image-to-volcengine.yml')"`
- `git diff --check`