### PR TITLE
fix pnpm runtime image tag variable

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -99,11 +99,11 @@ jobs:
             withoutDigest=${withoutRegistry%@*}
             echo $withoutDigest
             TAG=${withoutDigest}
-            echo "IMAGE_TAG=${TAG}"
+            echo "COSCENE_IMAGE_TAG=${TAG}"
           fi
-          IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -t latest
+          COSCENE_IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -t latest
           if [[ $TAG != 'latest' ]]; then
-            IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -q
+            COSCENE_IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -q
           fi
           echo "TAG=$TAG" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- pass the computed runtime image tag to Skaffold as `COSCENE_IMAGE_TAG` instead of `IMAGE_TAG`
- keep the published image tag output unchanged

## Root Cause
The mono skaffold config needs a non-conflicting environment variable because Skaffold exposes `IMAGE_TAG` as a generated Docker build arg template value. When the pnpm workflow runs `skaffold build -t latest`, that generated value becomes `latest`; using `COSCENE_IMAGE_TAG` avoids the collision.

## Validation
- Node static check verifying the workflow passes `COSCENE_IMAGE_TAG` into both latest and release builds
- Bash simulation for release and push branches with fake `skaffold`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/image-push-pnpm.yml')"`
- `git diff --check`

Paired with coscene-io/mono#3042.