### PR TITLE
Revert "fix volcengine image copy runner (#75)"

### DIFF
--- a/.github/workflows/cp-image-to-volcengine.yml
+++ b/.github/workflows/cp-image-to-volcengine.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   cp-image-use-gh:
-    runs-on: ubuntu-latest
+    runs-on: ["aliyun", "X64"]
     timeout-minutes: 5
     continue-on-error: true
     steps:


### PR DESCRIPTION
This reverts commit f69eaf42e8d167282925011e2f5cca0e50eadaf6.