### PR TITLE
Update CD workflow actions for Node 24 runtimes

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -43,13 +43,13 @@ jobs:
           check-latest: true
           cache: false
       - name: Set up netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: buf.build
           username: ${{ secrets.BUF_USERNAME }}
           password: ${{ secrets.BUF_TOKEN }}
       - name: Set up github netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: github.com
           username: ${{ secrets.GH_PACKAGES_ORG_USERNAME }}

--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -36,31 +36,31 @@ jobs:
         with:
           go-version: ">=1.20.2"
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.0.1
+        uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:
           skaffold: '2.3.1'
       - name: ACR login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
       - name: Set up buf netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: buf.build
           username: ${{ secrets.BUF_USERNAME }}
           password: ${{ secrets.BUF_TOKEN }}
       - name: Set up github netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: github.com
           username: ${{ secrets.GH_PACKAGES_ORG_USERNAME }}
           password: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
         run: |

--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: ">=1.20.2"
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.1.0
+        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: ">=1.20.2"
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+        uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -51,7 +51,7 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+      - uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -46,18 +46,18 @@ jobs:
         with:
           arguments: build -x test -x check
       - name: ACR login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v2.0.1
+      - uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:
           skaffold: '2.3.1'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Build and push images
         id: build-and-push
         run: |

--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -51,7 +51,7 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v2.1.0
+      - uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -38,7 +38,7 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v2.1.0
+      - uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -38,7 +38,7 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+      - uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -33,18 +33,18 @@ jobs:
         with:
           arguments: build -x test -x check
       - name: ACR login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v2.0.1
+      - uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:
           skaffold: '2.3.1'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Build and push images
         id: build-and-push
         run: |

--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ inputs.build != '' }}
         run: pnpm run ${{ inputs.build }}
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+        uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ inputs.build != '' }}
         run: pnpm run ${{ inputs.build }}
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.1.0
+        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -67,25 +67,25 @@ jobs:
         if: ${{ inputs.build != '' }}
         run: pnpm run ${{ inputs.build }}
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.0.1
+        uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:
           skaffold: "2.3.1"
       - name: ACR login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
       - name: Set up github netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: github.com
           username: ${{ secrets.GH_PACKAGES_ORG_USERNAME }}
           password: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
         run: |

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+        uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.1.0
+        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -40,25 +40,25 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.0.1
+        uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:
           skaffold: "2.3.1"
       - name: ACR login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
       - name: Set up github netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: github.com
           username: ${{ secrets.GH_PACKAGES_ORG_USERNAME }}
           password: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
         run: |

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+        uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -22,31 +22,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.0.1
+        uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:
           skaffold: '2.3.1'
       - name: ACR login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: coseus.azurecr.io
           username: ${{ secrets.ACR_ADMIN_USERNAME }}
           password: ${{ secrets.ACR_ADMIN_PASSWORD }}
       - name: Set up buf netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: buf.build
           username: ${{ secrets.BUF_USERNAME }}
           password: ${{ secrets.BUF_TOKEN }}
       - name: Set up github netrc
-        uses: extractions/netrc@v1
+        uses: extractions/netrc@v3
         with:
           machine: github.com
           username: ${{ secrets.GH_PACKAGES_ORG_USERNAME }}
           password: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
         run: |

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.1.0
+        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/pg-service-java-deploy.yml
+++ b/.github/workflows/pg-service-java-deploy.yml
@@ -55,7 +55,7 @@ jobs:
           registry: coseus.azurecr.io
           username: ${{ secrets.ACR_ADMIN_USERNAME }}
           password: ${{ secrets.ACR_ADMIN_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+      - uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/pg-service-java-deploy.yml
+++ b/.github/workflows/pg-service-java-deploy.yml
@@ -55,7 +55,7 @@ jobs:
           registry: coseus.azurecr.io
           username: ${{ secrets.ACR_ADMIN_USERNAME }}
           password: ${{ secrets.ACR_ADMIN_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v2.1.0
+      - uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/pg-service-java-deploy.yml
+++ b/.github/workflows/pg-service-java-deploy.yml
@@ -50,12 +50,12 @@ jobs:
         with:
           arguments: build -x test -x check
       - name: ACR login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: coseus.azurecr.io
           username: ${{ secrets.ACR_ADMIN_USERNAME }}
           password: ${{ secrets.ACR_ADMIN_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v2.0.1
+      - uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.1.0
+        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v2.0.1
+        uses: coscene-io/setup-cd-tools@v2.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@fix/skaffold-gcs-download
+        uses: coscene-io/setup-cd-tools@v26.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:


### PR DESCRIPTION
## Summary
- use coscene-io/setup-cd-tools@v2.1.0 in reusable CD workflows
- upgrade docker/login-action and docker/setup-buildx-action to v4
- upgrade extractions/netrc to v3

## Why
GitHub Actions is deprecating JavaScript actions running on Node 20 and will force Node 24 by default. These workflow action upgrades remove the Node 20 runtime warning from image-push/build jobs while keeping application build Node versions unchanged.

## Validation
- git diff --check
- parsed all .github/workflows/*.yml with Ruby YAML
- verified no old warning-related action references remain
- verified coscene-io/setup-cd-tools@v2.1.0 resolves to action.yml with using: node24
- verified docker/login-action@v4 and docker/setup-buildx-action@v4 use node24
- verified extractions/netrc@v3 uses node24