### PR TITLE
Use setup-cd-tools v2.1.1

### DIFF
--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: ">=1.20.2"
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v26.1.1
+        uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -51,7 +51,7 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v26.1.1
+      - uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -38,7 +38,7 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com/coscene
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v26.1.1
+      - uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ inputs.build != '' }}
         run: pnpm run ${{ inputs.build }}
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v26.1.1
+        uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v26.1.1
+        uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v26.1.1
+        uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/pg-service-java-deploy.yml
+++ b/.github/workflows/pg-service-java-deploy.yml
@@ -55,7 +55,7 @@ jobs:
           registry: coseus.azurecr.io
           username: ${{ secrets.ACR_ADMIN_USERNAME }}
           password: ${{ secrets.ACR_ADMIN_PASSWORD }}
-      - uses: coscene-io/setup-cd-tools@v26.1.1
+      - uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Set up CD tools
-        uses: coscene-io/setup-cd-tools@v26.1.1
+        uses: coscene-io/setup-cd-tools@v2.1.1
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
         with:


### PR DESCRIPTION
## Summary

Updates reusable GitHub workflows to use `coscene-io/setup-cd-tools@v2.1.1`.

## Impact

Workflows that set up CD tooling now pin to the requested `setup-cd-tools` version.

## Validation

- `git diff --check`
- `rg -n "coscene-io/setup-cd-tools@v26\\.1\\.1" .github/workflows` returned no matches
- `rg -n "coscene-io/setup-cd-tools@v2\\.1\\.1" .github/workflows` found 8 workflow references