### PR TITLE
Update Node workflows to v24

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node env
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
       - name: Install Dependencies
         if: ${{ inputs.build != '' }}

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node env
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "yarn"
       - name: Install Dependencies
         run: yarn install


### PR DESCRIPTION
## Summary

- Update the reusable Yarn image workflow to run on Node.js 24.
- Update the reusable pnpm image workflow to run on Node.js 24.

## Impact

Projects consuming these reusable workflows will build frontend image jobs with Node.js 24 instead of Node.js 22.

## Validation

- `git diff --cached --check`
- Verified all workflow `node-version` entries now use `24`.