### PR TITLE
feat: allow custom go image tags

### DIFF
--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      tag:
+        description: image tag to build and push
+        required: false
+        type: string
+        default: latest
 
     outputs:
       tag:
@@ -63,9 +68,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
         run: |
           cd ${{ inputs.workspace }}
-          skaffold build --build-concurrency=0 -t latest
+          skaffold build --build-concurrency=0 -t "$IMAGE_TAG"
           if [[ ${{ github.event_name }} == 'release' || ${{ github.event_name }} == 'prerelease' ]]; then
             result=$(skaffold build --build-concurrency=0 -q | jq '.builds[0].tag')
             echo $result
@@ -75,7 +82,7 @@ jobs:
             echo $withoutDigest
             echo "TAG=${withoutDigest}" >> $GITHUB_OUTPUT
           else
-            echo "TAG=latest" >> $GITHUB_OUTPUT
+            echo "TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           fi
 
   cp-image-to-volcengine:


### PR DESCRIPTION
## Summary

Go image reusable workflows can now build a caller-selected image tag while keeping `latest` as the default. Release and prerelease runs still derive the published tag from skaffold output, so existing release behavior remains unchanged.

## Test Plan

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/image-push-go.yml"); puts "ok"'`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Validate with a caller workflow that passes a non-`latest` `tag` to `image-push-go.yml`.
- Healthy signals: skaffold builds and pushes the selected tag, and downstream copy/callout jobs receive the same tag.
- Failure signals: GitHub rejects the reusable workflow input, skaffold still publishes `latest`, or downstream jobs cannot find the selected tag.
- Rollback trigger: revert this workflow input change if existing callers without `tag` stop publishing `latest`.
- Owner/window: first consuming workflow PR validates the new input before merging its caller-side change.
