### PR TITLE
fix: remove fixed workflow environments

### DIFF
--- a/.github/workflows/helm-upgrade.yml
+++ b/.github/workflows/helm-upgrade.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   helm-upgrade:
     runs-on: ubuntu-latest
-    environment: azure-dev-east-us
     timeout-minutes: 1
     steps:
       - name: AKS login

--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -25,7 +25,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: volcengine-dev-cn-shanghai
     outputs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:

--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -19,7 +19,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: azure-dev-east-us
     outputs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     services:

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: azure-dev-east-us
     outputs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: azure-dev-east-us
     outputs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:

--- a/.github/workflows/pg-service-java-deploy.yml
+++ b/.github/workflows/pg-service-java-deploy.yml
@@ -23,7 +23,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: azure-dev-east-us
     outputs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     services:

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   sub-chart-upgrade:
     runs-on: ubuntu-latest
-    environment: volcengine-dev-cn-shanghai
     timeout-minutes: 1
     steps:
       - name: Set up CD tools


### PR DESCRIPTION
## Summary
Reusable workflow callers no longer get forced into the legacy `azure-dev-east-us` or `volcengine-dev-cn-shanghai` GitHub Environments when they use the shared build and deploy templates. This keeps the templates from creating misleading deployment environment associations while preserving their existing secrets and workflow behavior.

## Validation
- `rg --hidden -n "^\\s*environment:\\s*(azure-dev-east-us|volcengine-dev-cn-shanghai)\\s*$" .github/workflows` returns no matches
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785476263&installation_id=141984720&pr_number=83&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F83&signature=e79e1ce34a8763c6f1954a3e33bfc050b97bd13724d85e100c3c4c97eaf1173b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->