### PR TITLE
Upgrade checkout and frontend GitHub Actions

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: [gcp]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Cache Go modules and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -34,7 +34,7 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Set up go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -31,7 +31,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -43,7 +43,7 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup pnpm from packageManager
         if: ${{ inputs.pnpm_version == '' }}
         uses: pnpm/action-setup@v6
@@ -56,7 +56,7 @@ jobs:
           version: ${{ inputs.pnpm_version }}
           run_install: false
       - name: Setup Node env
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       lfs:
-        description: "actions/checkout@v4 lfs"
+        description: "actions/checkout lfs"
         required: true
         type: boolean
 
@@ -28,12 +28,12 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: ${{ inputs.lfs }}
       - run: corepack enable yarn
       - name: Setup Node env
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: "yarn"

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -19,7 +19,7 @@ jobs:
       tag: ${{ steps.build-and-push.outputs.TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up CD tools
         uses: coscene-io/setup-cd-tools@v2.1.1
         env:

--- a/.github/workflows/pg-service-java-deploy.yml
+++ b/.github/workflows/pg-service-java-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` to v7 across reusable build and deploy workflows
- upgrade `actions/setup-node` to v7 in the pnpm and Yarn workflows
- upgrade `actions/cache` to v6 in the Go build workflow
- keep Go setup, Java/Gradle, Kubernetes, and Helmfile action versions unchanged

## Why

Adopt the current stable action runtimes and dependency fixes while limiting the scope to checkout, cache, and frontend-related workflow dependencies.

## Impact

Workflow inputs, outputs, and build commands are unchanged.

## Validation

- parsed all 13 workflow YAML files successfully
- passed `actionlint` structure and expression checks, excluding existing custom runner-label checks and warnings from intentionally retained legacy actions
- passed `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787465418&installation_model_id=425002&pr_number=84&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F84&signature=8957e5402db49b0ca55c2361aa38d56140553015623b1bdfd5a70cb6063d715e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->