### PR TITLE
Add curl-based Feishu notification action

### DIFF
--- a/.github/actions/feishu-notify/action.yml
+++ b/.github/actions/feishu-notify/action.yml
@@ -1,0 +1,20 @@
+name: Feishu text notification
+description: Send a text message to a Feishu custom bot webhook
+
+inputs:
+  webhook-url:
+    description: Feishu custom bot webhook URL
+    required: true
+  text:
+    description: Text message to send
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send Feishu notification
+      shell: bash
+      env:
+        FEISHU_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        FEISHU_TEXT: ${{ inputs.text }}
+      run: bash "$GITHUB_ACTION_PATH/send.sh"

--- a/.github/actions/feishu-notify/send.sh
+++ b/.github/actions/feishu-notify/send.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly MAX_PAYLOAD_BYTES=20000
+
+error() {
+  printf '::error::%s\n' "$*" >&2
+}
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    error "Required command is unavailable: ${command_name}"
+    exit 1
+  fi
+}
+
+if [[ -z "${FEISHU_WEBHOOK_URL:-}" ]]; then
+  error 'Missing required input: webhook-url'
+  exit 1
+fi
+
+if [[ "$FEISHU_WEBHOOK_URL" != https://* ]]; then
+  error 'Feishu webhook URL must use HTTPS'
+  exit 1
+fi
+
+if [[ -z "${FEISHU_TEXT:-}" ]]; then
+  error 'Missing required input: text'
+  exit 1
+fi
+
+require_command curl
+require_command jq
+
+payload="$(jq -cn --arg text "$FEISHU_TEXT" \
+  '{msg_type: "text", content: {text: $text}}')"
+payload_bytes="$(printf '%s' "$payload" | wc -c | tr -d '[:space:]')"
+
+if ((payload_bytes > MAX_PAYLOAD_BYTES)); then
+  error "Feishu payload exceeds ${MAX_PAYLOAD_BYTES} bytes: ${payload_bytes}"
+  exit 1
+fi
+
+payload_file="$(mktemp)"
+response_file="$(mktemp)"
+trap 'rm -f -- "$payload_file" "$response_file"' EXIT
+
+printf '%s' "$payload" >"$payload_file"
+
+if ! http_code="$(
+  curl \
+    --silent \
+    --show-error \
+    --proto '=https' \
+    --connect-timeout 5 \
+    --max-time 20 \
+    --header 'Content-Type: application/json; charset=utf-8' \
+    --data-binary "@${payload_file}" \
+    --output "$response_file" \
+    --write-out '%{http_code}' \
+    "$FEISHU_WEBHOOK_URL"
+)"; then
+  error 'Feishu webhook transport failure'
+  exit 1
+fi
+
+if [[ ! "$http_code" =~ ^2[0-9]{2}$ ]]; then
+  error "Feishu webhook HTTP failure: ${http_code}"
+  exit 1
+fi
+
+if ! jq -e 'type == "object"' "$response_file" >/dev/null 2>&1; then
+  error 'Feishu webhook returned an invalid JSON response'
+  exit 1
+fi
+
+if ! jq -e '
+  def is_zero: . == 0 or . == "0";
+  if has("code") then
+    .code | is_zero
+  elif has("StatusCode") then
+    .StatusCode | is_zero
+  else
+    false
+  end
+' "$response_file" >/dev/null; then
+  error_details="$(
+    jq -r '
+      "Feishu rejected request: code=\(.code // .StatusCode // "missing") " +
+      "message=\((.msg // .StatusMessage // "missing") | tostring | gsub("[\r\n]"; " "))"
+    ' "$response_file"
+  )"
+  error "$error_details"
+  exit 1
+fi
+
+printf 'Feishu notification sent successfully.\n'


### PR DESCRIPTION
## Summary

- add a reusable composite action for Feishu text notifications
- build request JSON safely with `jq` and send it with `curl`
- validate HTTPS, payload size, transport/HTTP status, and Feishu business response codes

## Why

`foxundermoon/feishu-action@v2` targets an obsolete JavaScript Actions runtime and has no Node 24 release. This first-stage change provides an internally maintained, shell-based replacement without changing existing workflow callers yet. A follow-up will pin callers to this PR's merged commit SHA.

## Impact

No existing workflow behavior changes in this PR. The new action requires Bash, curl, and jq on the runner. It fails on invalid inputs, payloads over 20,000 bytes, transport or non-2xx HTTP errors, invalid JSON, and nonzero Feishu business codes; POST requests are not automatically retried.

## Validation

- `bash -n .github/actions/feishu-notify/send.sh`
- `shellcheck .github/actions/feishu-notify/send.sh`
- `yq eval '.' .github/actions/feishu-notify/action.yml`
- fake-curl success-path check with multiline text
- fake-curl business-error check for Feishu code `19024`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787471156&installation_model_id=425002&pr_number=85&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F85&signature=382fd791a98d35814411149a73eed7ea98d4b9edede48d9fc40301426ed5b63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->