### PR TITLE
Replace deprecated Feishu action

### DIFF
--- a/.github/workflows/helm-upgrade.yml
+++ b/.github/workflows/helm-upgrade.yml
@@ -34,13 +34,11 @@ jobs:
         run: |
           helm upgrade -n coscene --reuse-values coscene coscene/coscene --set ${{ inputs.sub-chart }}.rollout=$GITHUB_SHA
       - name: Notification to Feishu
-        uses: foxundermoon/feishu-action@v2
+        uses: coscene-io/cicd-templates/.github/actions/feishu-notify@824434d6b2fc762f55f112adec821a36ac161b46
         with:
-          url: ${{ secrets.FEISHU_BOT_WEBHOOK_URL_RHODE_ISLAND }}
-          msg_type: text
-          content: |
-            text: |
-              A new version of ${{ github.repository }} has been deployed.
-              GitHubEvent: ${{ github.event_name }}
-              committer: ${{ github.actor }}
-              baseRef: ${{ github.ref }}
+          webhook-url: ${{ secrets.FEISHU_BOT_WEBHOOK_URL_RHODE_ISLAND }}
+          text: |
+            A new version of ${{ github.repository }} has been deployed.
+            GitHubEvent: ${{ github.event_name }}
+            committer: ${{ github.actor }}
+            baseRef: ${{ github.ref }}

--- a/.github/workflows/image-callout.yml
+++ b/.github/workflows/image-callout.yml
@@ -33,18 +33,15 @@ jobs:
           echo "AliCloud image: $ALICLOUD/${{ inputs.project }}:$TAG" >> $GITHUB_STEP_SUMMARY
           echo "AliCloud image: $ALICLOUD/${{ inputs.project }}:latest" >> $GITHUB_STEP_SUMMARY
       - name: Notification to Feishu
-        uses: foxundermoon/feishu-action@v2
+        uses: coscene-io/cicd-templates/.github/actions/feishu-notify@824434d6b2fc762f55f112adec821a36ac161b46
         with:
-          url: ${{ secrets.FEISHU_BOT_WEBHOOK_URL_IMAGE_BROADCAST }}
-          msg_type: text
-          content: |
-            text: |
-              A new version of ${{ github.repository }} image has been published.
-              GitHubEvent: ${{ github.event_name }}
-              committer: ${{ github.actor }}
-              baseRef: ${{ github.ref }}
-              Azure image: ${{ env.AZURE }}/${{ inputs.project }}:${{ env.TAG }}
-              Azure image: ${{ env.AZURE }}/${{ inputs.project }}:latest
-              AliCloud image: ${{ env.ALICLOUD }}/${{ inputs.project }}:${{ env.TAG }}
-              AliCloud image: ${{ env.ALICLOUD }}/${{ inputs.project }}:latest
-
+          webhook-url: ${{ secrets.FEISHU_BOT_WEBHOOK_URL_IMAGE_BROADCAST }}
+          text: |
+            A new version of ${{ github.repository }} image has been published.
+            GitHubEvent: ${{ github.event_name }}
+            committer: ${{ github.actor }}
+            baseRef: ${{ github.ref }}
+            Azure image: ${{ env.AZURE }}/${{ inputs.project }}:${{ env.TAG }}
+            Azure image: ${{ env.AZURE }}/${{ inputs.project }}:latest
+            AliCloud image: ${{ env.ALICLOUD }}/${{ inputs.project }}:${{ env.TAG }}
+            AliCloud image: ${{ env.ALICLOUD }}/${{ inputs.project }}:latest

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -28,14 +28,12 @@ jobs:
         run: |
           kubectl rollout restart deployment/${{ inputs.deployment-name }} -n coscene
       - name: Notification to Feishu
-        uses: foxundermoon/feishu-action@v2
+        uses: coscene-io/cicd-templates/.github/actions/feishu-notify@824434d6b2fc762f55f112adec821a36ac161b46
         with:
-          url: ${{ secrets.FEISHU_BOT_WEBHOOK_URL_RHODE_ISLAND }}
-          msg_type: text
-          content: |
-            text: |
-              Sub-chart upgrade!
-              the deployment ${{ inputs.deployment-name }} restarted.
-              GitHubEvent: ${{ github.event_name }}
-              committer: ${{ github.actor }}
-              baseRef: ${{ github.ref }}
+          webhook-url: ${{ secrets.FEISHU_BOT_WEBHOOK_URL_RHODE_ISLAND }}
+          text: |
+            Sub-chart upgrade!
+            the deployment ${{ inputs.deployment-name }} restarted.
+            GitHubEvent: ${{ github.event_name }}
+            committer: ${{ github.actor }}
+            baseRef: ${{ github.ref }}


### PR DESCRIPTION
## Summary

- replace all three `foxundermoon/feishu-action@v2` usages with the internal curl-based Feishu notification action
- pin the replacement to immutable commit `824434d6b2fc762f55f112adec821a36ac161b46`
- preserve the existing webhook secrets and notification text

## Why

The third-party action targets an obsolete GitHub Actions JavaScript runtime and has no Node 24 release. The internal composite action added in #85 removes that dependency and validates Feishu business responses in addition to transport and HTTP status.

## Impact

Notification steps now require Bash, curl, and jq. Transport failures, non-2xx responses, invalid JSON, and nonzero Feishu business codes fail the step. Requests are not automatically retried.

## Validation

- `yq eval '.'` for all three changed workflows
- targeted `actionlint` for all three changed workflows
- `git diff --check`
- confirmed no `foxundermoon/feishu-action@v2` references remain in `.github/workflows`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787472560&installation_model_id=425002&pr_number=86&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F86&signature=00700440d696e7b6d309eeab98a6904086769d37ce677d11c3fe70ea15e1c6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->