### PR TITLE
Optimize pnpm image publishing

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -45,24 +45,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup pnpm from packageManager
-        if: ${{ inputs.pnpm_version == '' }}
+        if: ${{ inputs.build != '' && inputs.pnpm_version == '' }}
         uses: pnpm/action-setup@v6
         with:
           run_install: false
       - name: Setup pnpm from workflow input
-        if: ${{ inputs.pnpm_version != '' }}
+        if: ${{ inputs.build != '' && inputs.pnpm_version != '' }}
         uses: pnpm/action-setup@v6
         with:
           version: ${{ inputs.pnpm_version }}
           run_install: false
       - name: Setup Node env
+        if: ${{ inputs.build != '' }}
         uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: "pnpm"
       - name: Install Dependencies
         if: ${{ inputs.build != '' }}
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Build
         if: ${{ inputs.build != '' }}
         run: pnpm run ${{ inputs.build }}
@@ -88,29 +89,40 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
+        env:
+          IS_RELEASE: ${{ github.event_name == 'release' }}
+          SKAFFOLD_PROFILE: ${{ inputs.profile }}
         run: |
-          PROFILE_ARG=$([ -n "${{ inputs.profile }}" ] && echo "-p ${{ inputs.profile }}" || echo "")
-          TAG=latest
-          if [[ ${{ github.event_name }} == 'release' || ${{ github.event_name }} == 'prerelease' ]]; then
-            result=$(skaffold build --build-concurrency=0 $PROFILE_ARG --dry-run -q | jq -r '.builds[0].tag')
-            echo $result
-            withoutRegistry=${result#*:}
-            echo $withoutRegistry
-            withoutDigest=${withoutRegistry%@*}
-            echo $withoutDigest
-            TAG=${withoutDigest}
-            echo "COSCENE_IMAGE_TAG=${TAG}"
+          set -euo pipefail
+
+          profile_args=()
+          if [[ -n "$SKAFFOLD_PROFILE" ]]; then
+            profile_args=(-p "$SKAFFOLD_PROFILE")
           fi
-          COSCENE_IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -t latest
-          if [[ $TAG != 'latest' ]]; then
-            COSCENE_IMAGE_TAG="$TAG" skaffold build --build-concurrency=0 $PROFILE_ARG -q
+
+          tag=latest
+          if [[ "$IS_RELEASE" == 'true' ]]; then
+            image_ref="$(skaffold build --build-concurrency=0 "${profile_args[@]}" --dry-run -q \
+              | jq -er '.builds[0].tag')"
+            repository="${image_ref%:*}"
+            tag="${image_ref##*:}"
+            tag="${tag%@*}"
+
+            COSCENE_IMAGE_TAG="$tag" skaffold build \
+              --build-concurrency=0 "${profile_args[@]}" -q
+            docker buildx imagetools create \
+              --tag "$repository:latest" \
+              "$repository:$tag"
+          else
+            COSCENE_IMAGE_TAG="$tag" skaffold build \
+              --build-concurrency=0 "${profile_args[@]}" -t latest -q
           fi
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+          echo "TAG=$tag" >> "$GITHUB_OUTPUT"
 
   cp-image-to-volcengine:
     needs:
       - build
-    uses: coscene-io/cicd-templates/.github/workflows/cp-image-to-volcengine.yml@main
+    uses: coscene-io/cicd-templates/.github/workflows/cp-image-to-volcengine.yml@6e09c726e1f720da6f0d9795f99873ad040368f0
     with:
       project: ${{ inputs.project }}
       tag: ${{ needs.build.outputs.tag }}
@@ -119,7 +131,7 @@ jobs:
   callout:
     needs:
       - build
-    uses: coscene-io/cicd-templates/.github/workflows/image-callout.yml@main
+    uses: coscene-io/cicd-templates/.github/workflows/image-callout.yml@6e09c726e1f720da6f0d9795f99873ad040368f0
     with:
       project: ${{ inputs.project }}
       tag: ${{ needs.build.outputs.tag }}


### PR DESCRIPTION
## Summary

- skip pnpm and Node setup when a Dockerfile performs the complete build
- build release images once, then create the `latest` registry tag without rebuilding layers
- use frozen lockfile installs for host builds
- pin nested reusable workflow calls to an immutable commit

## Why

The pnpm image workflow previously performed two complete Skaffold builds for releases. It also installed the Node toolchain for self-building Dockerfiles such as Gidle, and nested reusable calls followed mutable `main` references.

## Validation

- `actionlint .github/workflows/image-push-pnpm.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787684464&installation_model_id=425002&pr_number=87&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F87&signature=739f3d54ac4533c103e7c10e7f0d09326f1b7968de0c80abaf7b0a336758bc1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->