### PR TITLE
Support scoped pnpm authentication in image builds

### DIFF
--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -36,7 +36,6 @@ jobs:
     env:
       BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
       BUF_BUILD_TOKEN: ${{ secrets.BUF_BUILD_TOKEN }}
-      GH_PACKAGES_ORG_TOKEN: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       NODE_OPTIONS: --max_old_space_size=16384
     outputs:
@@ -62,6 +61,8 @@ jobs:
           cache: "pnpm"
       - name: Install Dependencies
         if: ${{ inputs.build != '' }}
+        env:
+          PNPM_CONFIG__AUTH: '{"https://npm.pkg.github.com":{"@coscene-io":{"authToken":"${{ secrets.GH_PACKAGES_ORG_TOKEN }}"}}}'
         run: pnpm install
       - name: Build
         if: ${{ inputs.build != '' }}
@@ -88,6 +89,8 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
+        env:
+          GH_PACKAGES_ORG_TOKEN: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
         run: |
           PROFILE_ARG=$([ -n "${{ inputs.profile }}" ] && echo "-p ${{ inputs.profile }}" || echo "")
           TAG=latest


### PR DESCRIPTION
## Summary

- authenticate pnpm installs with the pnpm 11 structured, scope-bound `PNPM_CONFIG__AUTH` value
- remove the GitHub Packages token from job-wide environment scope
- expose the raw token only to the Skaffold Docker build step that forwards it to BuildKit

## Why

pnpm 11 no longer expands credentials from a checked-in project `.npmrc`. Reusable image workflows that install private `@coscene-io` packages therefore need a trusted CI authentication source. Keeping the credential step-scoped also prevents build and setup steps from receiving registry access unnecessarily.

## Validation

- `actionlint -shellcheck= .github/workflows/image-push-pnpm.yml`
- `git diff --check`

Full actionlint still reports existing SC2086 findings in the unchanged Skaffold shell body.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787902980&installation_model_id=425002&pr_number=88&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F88&signature=3358ba6f1d71ea81510cab2c1ac97506f75122bc662f3601d426d707a1699b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->