### PR TITLE
fix(ci): support isolated Go module caches

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -18,6 +18,16 @@ on:
         required: false
         type: boolean
         default: true
+      isolated_module_cache:
+        description: Use a workspace-local Go module cache
+        required: false
+        type: boolean
+        default: false
+      download_modules:
+        description: Download standalone module dependencies before linting
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -27,15 +37,17 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Configure isolated Go module cache
+        if: ${{ inputs.isolated_module_cache }}
+        run: echo "GOMODCACHE=${GITHUB_WORKSPACE}/.cache/go-mod" >> "${GITHUB_ENV}"
       - name: Cache Go modules and build
         uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.workspace)) }}
-          restore-keys: |
-            go-${{ runner.os }}-${{ inputs.go_version }}-
+            ${{ inputs.isolated_module_cache && format('{0}/.cache/go-mod', github.workspace) || '~/go/pkg/mod' }}
+          key: ${{ inputs.isolated_module_cache && format('go-{0}-{1}-{2}-{3}', runner.os, inputs.go_version, inputs.workspace, hashFiles(format('{0}/go.sum', inputs.workspace))) || format('go-{0}-{1}-{2}', runner.os, inputs.go_version, hashFiles(format('{0}/go.sum', inputs.workspace))) }}
+          restore-keys: ${{ inputs.isolated_module_cache && format('go-{0}-{1}-{2}-', runner.os, inputs.go_version, inputs.workspace) || format('go-{0}-{1}-', runner.os, inputs.go_version) }}
       - name: Setup go
         uses: actions/setup-go@v6
         with:
@@ -54,6 +66,12 @@ jobs:
           machine: github.com
           username: ${{ secrets.GH_PACKAGES_ORG_USERNAME }}
           password: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
+      - name: Download Go modules
+        if: ${{ inputs.download_modules }}
+        working-directory: ${{ inputs.workspace }}
+        env:
+          GOWORK: "off"
+        run: go mod download
       - name: Go lint
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
## Summary

- add an opt-in workspace-local Go module cache to the reusable Go workflow
- add opt-in standalone module dependency preloading before lint
- preserve the existing behavior for all current callers by default

## Verification

- `actionlint -ignore 'label "gcp" is unknown' .github/workflows/build-go.yml`
- `git diff --check`
- Matrix action-controller reusable workflow integration: https://github.com/coscene-io/matrix/actions/runs/30922078919

## Integration

Matrix action-controller enabled both inputs and passed isolated cache configuration, standalone dependency download, lint, and build while running concurrently with the server build.