### PR TITLE
fix(ci): restore Go image publishing

### DIFF
--- a/.github/workflows/image-push-go.yml
+++ b/.github/workflows/image-push-go.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Docker build & push
         id: build-and-push
         env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
           IMAGE_TAG: ${{ inputs.tag }}
         run: |
           cd ${{ inputs.workspace }}


### PR DESCRIPTION
## Summary

Restore Go image publishing to registries that reject Buildx's default provenance manifest. The reusable workflow now disables only implicit attestations for every `image-push-go.yml` consumer, without requiring service repositories to change their Skaffold build commands; callers can still request attestations explicitly.

The failure was observed in [Matrix Release CD run 31663926998](https://github.com/coscene-io/matrix/actions/runs/31663926998/job/94360240193): `denied: unknown manifest class for application/vnd.oci.empty.v1+json`.

Related: coscene-io/matrix#812

## Validation

- Parsed the updated reusable workflow as valid YAML.
- Confirmed Buildx v0.28.0 recognizes `BUILDX_NO_DEFAULT_ATTESTATIONS=1`.
- Completed a local no-push Buildx build with the environment variable set.
- Ran `git diff --check` successfully.
- A real ACR push remains for consumer workflow verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789204839&installation_model_id=425002&pr_number=92&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F92&signature=3a82f0eb3c5d8ebdbcb459b75fb872f8222cfd04875aadea56c246958918cc98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->