### PR TITLE
fix(ci): cover all Buildx image workflows

### DIFF
--- a/.github/workflows/image-push-java-with-db.yml
+++ b/.github/workflows/image-push-java-with-db.yml
@@ -59,6 +59,8 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Build and push images
         id: build-and-push
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
         run: |
           skaffold build --build-concurrency=0 -t latest
           if [[ ${{ github.event_name }} == 'release' || ${{ github.event_name }} == 'prerelease' ]]; then

--- a/.github/workflows/image-push-java.yml
+++ b/.github/workflows/image-push-java.yml
@@ -46,6 +46,8 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Build and push images
         id: build-and-push
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
         run: |
           skaffold build --build-concurrency=0 -t latest
           if [[ ${{ github.event_name }} == 'release' || ${{ github.event_name }} == 'prerelease' ]]; then

--- a/.github/workflows/image-push-pnpm.yml
+++ b/.github/workflows/image-push-pnpm.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Docker build & push
         id: build-and-push
         env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
           GH_PACKAGES_ORG_TOKEN: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
           MEASURE_RESOURCES: ${{ inputs.measure_resources }}
           PROFILE: ${{ inputs.profile }}

--- a/.github/workflows/image-push-yarn.yml
+++ b/.github/workflows/image-push-yarn.yml
@@ -61,6 +61,8 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
         run: |
           skaffold build --build-concurrency=0 -t latest
           if [[ ${{ github.event_name }} == 'release' || ${{ github.event_name }} == 'prerelease' ]]; then

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -48,6 +48,8 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Docker build & push
         id: build-and-push
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
         run: |
           skaffold build --build-concurrency=0 -t latest
           result=$(skaffold build --build-concurrency=0 -q | jq '.builds[0].tag')


### PR DESCRIPTION
## Summary

Complete the registry compatibility fix introduced by #92. Every remaining reusable workflow that sets up Docker Buildx now disables implicit provenance attestations in its image build step, so Java, Java-with-DB, Yarn, PNPM, and generic image builds do not require consumer repositories to change their Skaffold commands.

Explicit `--provenance` or `--attest` options remain available to consumers that target a compatible registry.

Related: #92

## Validation

- Parsed every workflow file as valid YAML.
- Confirmed the six workflows using `docker/setup-buildx-action` are exactly the six workflows defining `BUILDX_NO_DEFAULT_ATTESTATIONS` after this change.
- Ran `git diff --check` successfully.
- Real registry pushes remain consumer workflow validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/cicd-templates/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789206178&installation_model_id=425002&pr_number=93&repository=coscene-io%2Fcicd-templates&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fcicd-templates%2Fpull%2F93&signature=44b71cf1f2e56135f0883d449247656f587996d45eb12e32cfd61071f4720bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->