### PR TITLE
Update all Kubernetes context actions to v5

### DIFF
--- a/.github/workflows/helm-upgrade.yml
+++ b/.github/workflows/helm-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: AKS login
-        uses: azure/k8s-set-context@v3
+        uses: azure/k8s-set-context@v5
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.AZURE_KUBE_CONFIG }}

--- a/.github/workflows/sub-chart-upgrade.yml
+++ b/.github/workflows/sub-chart-upgrade.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           kubectl: '1.22.2'
       - name: VKE login
-        uses: azure/k8s-set-context@v3
+        uses: azure/k8s-set-context@v5
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.VOLCENGINE_DEV_KUBE_CONFIG }}


### PR DESCRIPTION
## Summary

- Upgrade every `azure/k8s-set-context` reference from `v3` to `v5` in the reusable CI/CD workflows.
- Cover both the active sub-chart upgrade workflow and the deprecated Helm upgrade workflow.
- Remove the Node.js 20 runtime deprecation warning from Kubernetes context setup steps.

## Validation

- `git diff --check`
- Ruby YAML parse of both changed workflow files
- Repository-wide scan confirms all `azure/k8s-set-context` references use `v5`
